### PR TITLE
fix: Fix AI content generation database connection issue (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ logs/
 
 # Extension build artifacts
 *.zip
+cloud_run_services_config.md

--- a/backend_websocket_server.py
+++ b/backend_websocket_server.py
@@ -3898,10 +3898,14 @@ async def generate_ai_content(
         }
 
     except Exception as e:
-        print(f"❌ Error generating AI content: {e}")
+        error_msg = str(e) or repr(e) or "Unknown error occurred"
+        print(f"❌ Error generating AI content: {error_msg}")
         import traceback
         traceback.print_exc()
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to generate AI content: {error_msg}"
+        )
 
 
 # ============================================================================

--- a/weekly_content_generator.py
+++ b/weekly_content_generator.py
@@ -92,9 +92,10 @@ async def analyze_user_profile(state: ContentGeneratorState) -> ContentGenerator
 
     user_id = state["user_id"]
 
-    # Get store connection
-    conn_string = os.getenv("POSTGRES_CONNECTION_STRING",
-                            "postgresql://postgres:password@localhost:5433/xgrowth")
+    # Get store connection (check POSTGRES_URI first for Cloud Run, then DATABASE_URL for local)
+    conn_string = (os.getenv("POSTGRES_URI") or
+                   os.getenv("DATABASE_URL") or
+                   "postgresql://postgres:password@localhost:5433/xgrowth")
 
     with PostgresStore.from_conn_string(conn_string) as store:
         # Load user's imported posts
@@ -190,9 +191,10 @@ async def analyze_competitors(state: ContentGeneratorState) -> ContentGeneratorS
 
     user_id = state["user_id"]
 
-    # Get store connection
-    conn_string = os.getenv("POSTGRES_CONNECTION_STRING",
-                            "postgresql://postgres:password@localhost:5433/xgrowth")
+    # Get store connection (check POSTGRES_URI first for Cloud Run, then DATABASE_URL for local)
+    conn_string = (os.getenv("POSTGRES_URI") or
+                   os.getenv("DATABASE_URL") or
+                   "postgresql://postgres:password@localhost:5433/xgrowth")
 
     with PostgresStore.from_conn_string(conn_string) as store:
         # Load social graph
@@ -714,7 +716,8 @@ async def generate_weekly_content(user_id: str, user_handle: str) -> List[Dict[s
     final_state = await app.ainvoke(initial_state)
 
     if final_state.get("error"):
-        raise Exception(final_state["error"])
+        error_msg = final_state["error"] or "Content generation failed with unknown error"
+        raise Exception(error_msg)
 
     print("\n" + "=" * 60)
     print(f"✅ Content Generation Complete!")


### PR DESCRIPTION
**Problem**: AI content generator was failing with empty error message because it couldn't connect to PostgreSQL database.

**Root Cause**: `weekly_content_generator.py` was using `POSTGRES_CONNECTION_STRING` environment variable which wasn't set. It fell back to localhost:5433 which doesn't exist in Cloud Run.

**Solution**:
1. Updated `weekly_content_generator.py` to use same database connection logic as backend:
   - Check `POSTGRES_URI` first (Cloud Run)
   - Fall back to `DATABASE_URL` (matches backend-api env var)
   - Final fallback to localhost for local development

2. Improved error handling:
   - Enhanced error messages in `backend_websocket_server.py` to prevent empty error details
   - Added fallback error message in `weekly_content_generator.py`

3. Added `cloud_run_services_config.md` to .gitignore (contains sensitive API keys)

**Testing**: Verified that DATABASE_URL env var exists in Cloud Run backend-api service pointing to Cloud SQL at 10.97.0.3:5432/parallel_universe_db

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)