### PR TITLE
feat: Add model selection support for automations

### DIFF
--- a/backend_websocket_server.py
+++ b/backend_websocket_server.py
@@ -5375,7 +5375,8 @@ async def list_cron_jobs(
                     "workflow_id": job.workflow_id,
                     "is_active": job.is_active,
                     "last_run_at": job.last_run_at.isoformat() if job.last_run_at else None,
-                    "created_at": job.created_at.isoformat()
+                    "created_at": job.created_at.isoformat(),
+                    "input_config": job.input_config,
                 }
                 for job in cron_jobs
             ]

--- a/cron_job_executor.py
+++ b/cron_job_executor.py
@@ -419,6 +419,11 @@ class CronJobExecutor:
 
             logger.info(f"🌐 CUA Host: {cua_host}, Port: {cua_port}")
 
+            # Extract model config from input_config (set by user in AutomationComposer)
+            model_name = cron_job.input_config.get("model_name", "claude-sonnet-4-5-20250929") if cron_job.input_config else "claude-sonnet-4-5-20250929"
+            model_provider = cron_job.input_config.get("model_provider", "anthropic") if cron_job.input_config else "anthropic"
+            logger.info(f"🧠 Using model: {model_name} (provider: {model_provider})")
+
             # Config with VNC URL for the agent to use browser automation
             config = {
                 "configurable": {
@@ -428,6 +433,8 @@ class CronJobExecutor:
                     "x-cua-port": cua_port,
                     "x-user-id": user_id,
                     "use_longterm_memory": True,
+                    "model_name": model_name,
+                    "model_provider": model_provider,
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add model selection support for cron job automations
- Users can now choose which AI model (Claude Sonnet, Claude Opus, GPT-5.2, etc.) powers their scheduled automations
- Extract `model_name` and `model_provider` from `input_config` in cron executor
- Pass model configuration to LangGraph agent via `config["configurable"]`
- Include `input_config` in GET `/api/cron-jobs` API response

## Test plan
- [ ] Create new automation with non-default model selected
- [ ] Verify `input_config` contains model_name in database
- [ ] Trigger "Run Now" and check logs show correct model being used
- [ ] Verify scheduled runs use the configured model

🤖 Generated with [Claude Code](https://claude.com/claude-code)